### PR TITLE
mysql: create index on state attribute

### DIFF
--- a/migrations/0000_db_mysql.py
+++ b/migrations/0000_db_mysql.py
@@ -89,6 +89,9 @@ CREATE UNIQUE INDEX name_index ON Workers(name)
 CREATE INDEX parent_index ON Jobs(parent)
 """,
 """
+CREATE INDEX state_index ON Jobs(state)
+""",
+"""
 CREATE INDEX job_id_index ON Dependencies(job_id)
 """,
 """


### PR DESCRIPTION
## Why
Optimize pickjob fetch request up to 20 times faster.

## How
When comparing `Jobs.state` with a string, the entire job dataset is scanned.

It becomes a major issue as long as we increase the number of Jobs and Workers.

The database system is quicly overloaded on the CPU side, by hitting all rows in Jobs table.

**Creating an index on state attribute, reduces drastically the hit.**

## Critical evaluation
Let's take the following SQL command triggered in `pickJob` method:
```SQL
SELECT J.id 
FROM Jobs as J 
INNER JOIN WorkerAffinities AS W 
ON ((J.h_affinity & W.affinity = J.h_affinity ) & ( J.h_affinity != 0 )) 
WHERE W.worker_name = 'xxxx' AND J.state = 'WAITING' AND NOT J.h_paused AND J.command != ''
ORDER BY W.ordering ASC, J.h_priority DESC, J.id ASC LIMIT 1
``` 

In the worst case scenrio, no jobs are pickable.

Let's say we have 400 renders, 1 pickJob request per minute and 65689 jobs.

We would have:
  - per minute 400*65689 = 26 275 600 scanned rows
  - per second: 437 926 scanned rows

That's huge.

## Result
On our side, we decreased CPU loading from 98% to 8%.
The SQL request above is 20 times faster now.
